### PR TITLE
cleanup and encode urls

### DIFF
--- a/ngshare_exchange/collect.py
+++ b/ngshare_exchange/collect.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import sys
 from collections import defaultdict
 import base64
 

--- a/ngshare_exchange/collect.py
+++ b/ngshare_exchange/collect.py
@@ -19,15 +19,15 @@ def groupby(l, key=lambda x: x):
 
 class ExchangeCollect(Exchange, ABCExchangeCollect):
     def _get_submission(self, course_id, assignment_id, student_id):
-        """
+        '''
         Returns the student's submission. A submission is a dictionary
-        containing a "timestamp" and "files" list. Each file in the list is a
-        dictionary containing the "path" relative to the assignment root and the
-        "content" as an ASCII representation of the base64 encoded bytes.
-        """
+        containing a 'timestamp' and 'files' list. Each file in the list is a
+        dictionary containing the 'path' relative to the assignment root and the
+        'content' as an ASCII representation of the base64 encoded bytes.
+        '''
 
         response = self.ngshare_api_get(
-            "/submission/{}/{}/{}".format(course_id, assignment_id, student_id)
+            '/submission/{}/{}/{}'.format(course_id, assignment_id, student_id)
         )
         if response is None:
             self.log.error('An error occurred downloading a submission.')
@@ -44,10 +44,10 @@ class ExchangeCollect(Exchange, ABCExchangeCollect):
         return {'timestamp': timestamp, 'files': files}
 
     def _get_submission_list(self, course_id, assignment_id):
-        """
+        '''
         Returns a list of submission entries. Each entry is a dictionary
-        containing the "student_id" and "timestamp".
-        """
+        containing the 'student_id' and 'timestamp'.
+        '''
         response = self.ngshare_api_get(
             '/submissions/{}/{}'.format(course_id, assignment_id)
         )
@@ -67,7 +67,7 @@ class ExchangeCollect(Exchange, ABCExchangeCollect):
 
     def init_src(self):
         if self.coursedir.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
+            self.fail('No course id specified. Re-run with --course flag.')
 
         records = self._get_submission_list(
             self.coursedir.course_id, self.coursedir.assignment_id
@@ -85,13 +85,13 @@ class ExchangeCollect(Exchange, ABCExchangeCollect):
     def copy_files(self):
         if len(self.src_records) == 0:
             self.log.warning(
-                "No submissions of '{}' for course '{}' to collect".format(
+                'No submissions of "{}" for course "{}" to collect'.format(
                     self.coursedir.assignment_id, self.coursedir.course_id
                 )
             )
         else:
             self.log.info(
-                "Processing {} submissions of '{}' for course '{}'".format(
+                'Processing {} submissions of "{}" for course "{}"'.format(
                     len(self.src_records),
                     self.coursedir.assignment_id,
                     self.coursedir.course_id,
@@ -128,14 +128,14 @@ class ExchangeCollect(Exchange, ABCExchangeCollect):
             if copy:
                 if updating:
                     self.log.info(
-                        "Updating submission: {} {}".format(
+                        'Updating submission: {} {}'.format(
                             student_id, self.coursedir.assignment_id
                         )
                     )
                     shutil.rmtree(dest_path)
                 else:
                     self.log.info(
-                        "Collecting submission: {} {}".format(
+                        'Collecting submission: {} {}'.format(
                             student_id, self.coursedir.assignment_id
                         )
                     )
@@ -150,19 +150,19 @@ class ExchangeCollect(Exchange, ABCExchangeCollect):
             else:
                 if self.update:
                     self.log.info(
-                        "No newer submission to collect: {} {}".format(
+                        'No newer submission to collect: {} {}'.format(
                             student_id, self.coursedir.assignment_id
                         )
                     )
                 else:
                     self.log.info(
-                        "Submission already exists, use --update to update: {} {}".format(
+                        'Submission already exists, use --update to update: {} {}'.format(
                             student_id, self.coursedir.assignment_id
                         )
                     )
 
     def do_copy(self, src, dest):
-        """
+        '''
         Repurposed version of Exchange.do_copy.
-        """
+        '''
         self.decode_dir(src, dest)

--- a/ngshare_exchange/course_management.py
+++ b/ngshare_exchange/course_management.py
@@ -96,7 +96,7 @@ def post(url, data):
     encoded_url = encode_url(url)
 
     try:
-        response = requests.post(encoded_url, data=data, headers=header)
+        response = requests.post(ngshare_url() + encoded_url, data=data, headers=header)
         response.raise_for_status()
     except requests.exceptions.ConnectionError:
         prRed('Could not establish connection to ngshare server')
@@ -110,7 +110,7 @@ def delete(url, data):
     header = get_header()
     encoded_url = encode_url(url)
     try:
-        response = requests.delete(encoded_url, data=data, headers=header)
+        response = requests.delete(ngshare_url() + encoded_url, data=data, headers=header)
         response.raise_for_status()
     except requests.exceptions.ConnectionError:
         prRed('Could not establish connection to ngshare server')
@@ -122,7 +122,7 @@ def delete(url, data):
 
 def create_course(args):
     instructors = args.instructors or []
-    url = '{}/course/{}'.format(ngshare_url(), args.course_id)
+    url = '/course/{}'.format(args.course_id)
     data = {'user': get_username(), 'instructors': json.dumps(instructors)}
 
     response = post(url, data)
@@ -132,7 +132,7 @@ def create_course(args):
 def add_student(args):
     # add student to ngshare
     student = User(args.student_id, args.first_name, args.last_name, args.email)
-    url = '{}/student/{}/{}'.format(ngshare_url(), args.course_id, student.id)
+    url = '/student/{}/{}'.format(args.course_id, student.id)
     data = {
         'user': get_username(),
         'first_name': student.first_name,
@@ -209,7 +209,7 @@ def add_students(args):
             student_dict['email'] = email
             students.append(student_dict)
 
-    url = '{}/students/{}'.format(ngshare_url(), args.course_id)
+    url = '/students/{}'.format(args.course_id)
     data = {'user': get_username(), 'students': json.dumps(students)}
 
     response = post(url, data)
@@ -251,7 +251,7 @@ def remove_students(args):
         if not args.no_gb:
             remove_jh_student(student, args.force)
 
-        url = '{}/student/{}/{}'.format(ngshare_url(), args.course_id, student)
+        url = '/student/{}/{}'.format(args.course_id, student)
         data = {'user': get_username()}
         response = delete(url, data)
         prGreen(
@@ -260,8 +260,8 @@ def remove_students(args):
 
 
 def add_instructor(args):
-    url = '{}/instructor/{}/{}'.format(
-        ngshare_url(), args.course_id, args.instructor_id
+    url = '/instructor/{}/{}'.format(
+        args.course_id, args.instructor_id
     )
     data = {
         'user': get_username(),
@@ -279,8 +279,8 @@ def add_instructor(args):
 
 
 def remove_instructor(args):
-    url = '{}/instructor/{}/{}'.format(
-        ngshare_url(), args.course_id, args.instructor_id
+    url = '/instructor/{}/{}'.format(
+        args.course_id, args.instructor_id
     )
     data = {'user': get_username()}
     response = delete(url, data)

--- a/ngshare_exchange/course_management.py
+++ b/ngshare_exchange/course_management.py
@@ -1,10 +1,7 @@
 import os
 import sys
-import getopt
 import requests
 import csv
-import pwd
-import grp
 import subprocess
 import json
 import argparse

--- a/ngshare_exchange/course_management.py
+++ b/ngshare_exchange/course_management.py
@@ -51,7 +51,7 @@ def ngshare_url():
             return _ngshare_url
         except Exception as e:
             prRed(
-                "Cannot determine ngshare URL. Please check your nbgrader_config.py!",
+                'Cannot determine ngshare URL. Please check your nbgrader_config.py!',
                 False,
             )
             prRed(e)

--- a/ngshare_exchange/course_management.py
+++ b/ngshare_exchange/course_management.py
@@ -96,7 +96,9 @@ def post(url, data):
     encoded_url = encode_url(url)
 
     try:
-        response = requests.post(ngshare_url() + encoded_url, data=data, headers=header)
+        response = requests.post(
+            ngshare_url() + encoded_url, data=data, headers=header
+        )
         response.raise_for_status()
     except requests.exceptions.ConnectionError:
         prRed('Could not establish connection to ngshare server')
@@ -110,7 +112,9 @@ def delete(url, data):
     header = get_header()
     encoded_url = encode_url(url)
     try:
-        response = requests.delete(ngshare_url() + encoded_url, data=data, headers=header)
+        response = requests.delete(
+            ngshare_url() + encoded_url, data=data, headers=header
+        )
         response.raise_for_status()
     except requests.exceptions.ConnectionError:
         prRed('Could not establish connection to ngshare server')
@@ -260,9 +264,7 @@ def remove_students(args):
 
 
 def add_instructor(args):
-    url = '/instructor/{}/{}'.format(
-        args.course_id, args.instructor_id
-    )
+    url = '/instructor/{}/{}'.format(args.course_id, args.instructor_id)
     data = {
         'user': get_username(),
         'first_name': args.first_name,
@@ -279,9 +281,7 @@ def add_instructor(args):
 
 
 def remove_instructor(args):
-    url = '/instructor/{}/{}'.format(
-        args.course_id, args.instructor_id
-    )
+    url = '/instructor/{}/{}'.format(args.course_id, args.instructor_id)
     data = {'user': get_username()}
     response = delete(url, data)
     prGreen(

--- a/ngshare_exchange/course_management.py
+++ b/ngshare_exchange/course_management.py
@@ -5,6 +5,7 @@ import csv
 import subprocess
 import json
 import argparse
+from urllib.parse import quote
 
 # https://www.geeksforgeeks.org/print-colors-python-terminal/
 def prRed(skk, exit=True):
@@ -86,11 +87,16 @@ def check_message(response):
     return response
 
 
+def encode_url(url):
+    return quote(url, safe='/', encoding=None, errors=None)
+
+
 def post(url, data):
     header = get_header()
+    encoded_url = encode_url(url)
 
     try:
-        response = requests.post(url, data=data, headers=header)
+        response = requests.post(encoded_url, data=data, headers=header)
         response.raise_for_status()
     except requests.exceptions.ConnectionError:
         prRed('Could not establish connection to ngshare server')
@@ -102,9 +108,9 @@ def post(url, data):
 
 def delete(url, data):
     header = get_header()
-
+    encoded_url = encode_url(url)
     try:
-        response = requests.delete(url, data=data, headers=header)
+        response = requests.delete(encoded_url, data=data, headers=header)
         response.raise_for_status()
     except requests.exceptions.ConnectionError:
         prRed('Could not establish connection to ngshare server')

--- a/ngshare_exchange/exchange.py
+++ b/ngshare_exchange/exchange.py
@@ -82,6 +82,7 @@ class Exchange(ABCExchange):
         return response
 
     def ngshare_api_request(self, method, url, data=None, params=None):
+        encoded_url = self.encode_url(url)
         try:
             headers = None
             if 'JUPYTERHUB_API_TOKEN' in os.environ:
@@ -91,7 +92,7 @@ class Exchange(ABCExchange):
                 }
             response = requests.request(
                 method,
-                self.ngshare_url + url,
+                self.ngshare_url + encoded_url,
                 headers=headers,
                 data=data,
                 params=params,
@@ -108,18 +109,13 @@ class Exchange(ABCExchange):
         return quote(url, safe='/', encoding=None, errors=None)
 
     def ngshare_api_get(self, url, params=None):
-        encoded_url = self.encode_url(url)
-        return self.ngshare_api_request('GET', encoded_url, params=params)
+        return self.ngshare_api_request('GET', url, params=params)
 
     def ngshare_api_post(self, url, data, params=None):
-        encoded_url = self.encode_url(url)
-        return self.ngshare_api_request(
-            'POST', encoded_url, data=data, params=params
-        )
+        return self.ngshare_api_request('POST', url, data=data, params=params)
 
     def ngshare_api_delete(self, url, params=None):
-        encoded_url = self.encode_url(url)
-        return self.ngshare_api_request('DELETE', encoded_url, params=params)
+        return self.ngshare_api_request('DELETE', url, params=params)
 
     assignment_dir = Unicode(
         '.',

--- a/ngshare_exchange/exchange.py
+++ b/ngshare_exchange/exchange.py
@@ -6,6 +6,7 @@ import requests
 import fnmatch
 from pathlib import Path
 from urllib.parse import quote
+from rapidfuzz import fuzz
 
 from textwrap import dedent
 
@@ -238,20 +239,12 @@ class Exchange(ABCExchange):
         return super(Exchange, self).start()
 
     def _assignment_not_found(self, src_path, other_path):
-        msg = 'Assignment not found at: {}'.format(src_path)
+        msg = "Assignment not found at: {}".format(src_path)
         self.log.fatal(msg)
         found = glob.glob(other_path)
         if found:
-
-            # Normally it is a bad idea to put imports in the middle of
-            # a function, but we do this here because otherwise fuzzywuzzy
-            # prints an annoying message about python-Levenshtein every
-            # time nbgrader is run.
-
-            from fuzzywuzzy import fuzz
-
             scores = sorted([(fuzz.ratio(self.src_path, x), x) for x in found])
-            self.log.error('Did you mean: %s', scores[-1][1])
+            self.log.error("Did you mean: %s", scores[-1][1])
 
         raise ExchangeError(msg)
 

--- a/ngshare_exchange/exchange.py
+++ b/ngshare_exchange/exchange.py
@@ -5,6 +5,7 @@ import glob
 import requests
 import fnmatch
 from pathlib import Path
+from urllib.parse import quote
 
 from textwrap import dedent
 
@@ -36,6 +37,7 @@ class Exchange(ABCExchange):
 
     @property
     def ngshare_url(self):
+
         if self._ngshare_url:
             return self._ngshare_url
         if 'PROXY_PUBLIC_SERVICE_HOST' in os.environ:
@@ -101,14 +103,20 @@ class Exchange(ABCExchange):
             return None
         return self._ngshare_api_check_error(response, url)
 
+    def encode_url(self, url)
+        return quote(url, safe='/', encoding=None, errors=None)
+
     def ngshare_api_get(self, url, params=None):
-        return self.ngshare_api_request('GET', url, params=params)
+        encoded_url = self.encode_url(url)
+        return self.ngshare_api_request('GET', encoded_url, params=params)
 
     def ngshare_api_post(self, url, data, params=None):
-        return self.ngshare_api_request('POST', url, data=data, params=params)
+        encoded_url = self.encode_url(url)
+        return self.ngshare_api_request('POST', encoded_url, data=data, params=params)
 
     def ngshare_api_delete(self, url, params=None):
-        return self.ngshare_api_request('DELETE', url, params=params)
+        encoded_url = self.encode_url(url)
+        return self.ngshare_api_request('DELETE', encoded_url, params=params)
 
     assignment_dir = Unicode(
         '.',

--- a/ngshare_exchange/exchange.py
+++ b/ngshare_exchange/exchange.py
@@ -103,7 +103,7 @@ class Exchange(ABCExchange):
             return None
         return self._ngshare_api_check_error(response, url)
 
-    def encode_url(self, url)
+    def encode_url(self, url):
         return quote(url, safe='/', encoding=None, errors=None)
 
     def ngshare_api_get(self, url, params=None):
@@ -112,7 +112,9 @@ class Exchange(ABCExchange):
 
     def ngshare_api_post(self, url, data, params=None):
         encoded_url = self.encode_url(url)
-        return self.ngshare_api_request('POST', encoded_url, data=data, params=params)
+        return self.ngshare_api_request(
+            'POST', encoded_url, data=data, params=params
+        )
 
     def ngshare_api_delete(self, url, params=None):
         encoded_url = self.encode_url(url)

--- a/ngshare_exchange/exchange.py
+++ b/ngshare_exchange/exchange.py
@@ -29,9 +29,9 @@ class Exchange(ABCExchange):
 
     _ngshare_url = Unicode(
         help=dedent(
-            """
+            '''
             Override default ngshare URL
-            """
+            '''
         ),
     ).tag(config=True)
 
@@ -43,16 +43,16 @@ class Exchange(ABCExchange):
         if 'PROXY_PUBLIC_SERVICE_HOST' in os.environ:
             # we are in a kubernetes environment, so dns based service discovery should work
             # assuming the service is called ngshare, which it should
-            return "http://proxy-public/services/ngshare"
+            return 'http://proxy-public/services/ngshare'
         else:
             raise ValueError(
-                "ngshare url not configured in a non-k8s environment! Please configure the URL manually in nbgrader_config.py"
+                'ngshare url not configured in a non-k8s environment! Please configure the URL manually in nbgrader_config.py'
             )
 
     def _ngshare_api_check_error(self, response, url):
         if response.status_code != requests.codes.ok:
             self.log.error(
-                "ngshare service returned invalid status code %d.",
+                'ngshare service returned invalid status code %d.',
                 response.status_code,
             )
 
@@ -60,7 +60,7 @@ class Exchange(ABCExchange):
             response = response.json()
         except Exception:
             self.log.exception(
-                "ngshare service returned non-JSON content: '%s'.",
+                'ngshare service returned non-JSON content: "%s".',
                 response.text,
             )
             return None
@@ -68,12 +68,12 @@ class Exchange(ABCExchange):
         if not response['success']:
             if 'message' not in response:
                 self.log.error(
-                    "ngshare endpoint %s returned failure without an error message.",
+                    'ngshare endpoint %s returned failure without an error message.',
                     url,
                 )
             else:
                 self.log.error(
-                    "ngshare endpoint %s returned failure: %s",
+                    'ngshare endpoint %s returned failure: %s',
                     url,
                     response['message'],
                 )
@@ -123,10 +123,10 @@ class Exchange(ABCExchange):
     assignment_dir = Unicode(
         '.',
         help=dedent(
-            """
+            '''
             Local path for storing student assignments.  Defaults to '.'
             which is normally Jupyter's notebook_dir.
-            """
+            '''
         ),
     ).tag(config=True)
 
@@ -142,12 +142,12 @@ class Exchange(ABCExchange):
     path_includes_course = Bool(
         False,
         help=dedent(
-            """
+            '''
             Whether the path for fetching/submitting  assignments should be
             prefixed with the course name. If this is `False`, then the path
             will be something like `./ps1`. If this is `True`, then the path
             will be something like `./course123/ps1`.
-            """
+            '''
         ),
     ).tag(config=True)
 
@@ -220,17 +220,17 @@ class Exchange(ABCExchange):
         return dir_tree
 
     def init_src(self):
-        """Compute and check the source paths for the transfer."""
+        '''Compute and check the source paths for the transfer.'''
 
         raise NotImplementedError
 
     def init_dest(self):
-        """Compute and check the destination paths for the transfer."""
+        '''Compute and check the destination paths for the transfer.'''
 
         raise NotImplementedError
 
     def copy_files(self):
-        """Actually do the file transfer."""
+        '''Actually do the file transfer.'''
 
         raise NotImplementedError
 
@@ -256,12 +256,12 @@ class Exchange(ABCExchange):
         raise ExchangeError(msg)
 
     def do_copy(self, src, dest, log=None):
-        """
+        '''
         Copy the src dir to the dest dir, omitting excluded
         file/directories, non included files, and too large files, as
         specified by the options coursedir.ignore, coursedir.include
         and coursedir.max_file_size.
-        """
+        '''
         shutil.copytree(
             src,
             dest,
@@ -274,7 +274,7 @@ class Exchange(ABCExchange):
         )
 
     def ignore_patterns(self):
-        """
+        '''
         Returns a function which decides whether or not a file should be
         ignored. The function has the signature
             ignore_patterns(directory, filename, filesize) -> bool
@@ -284,7 +284,7 @@ class Exchange(ABCExchange):
         will be ignored. If self.coursedir.include exists, filenames not
         matching the patterns will be ignored. If self.coursedir.max_file_size
         exists, files exceeding that size in kilobytes will be ignored.
-        """
+        '''
         exclude = self.coursedir.ignore
         include = self.coursedir.include
         max_file_size = self.coursedir.max_file_size
@@ -297,7 +297,7 @@ class Exchange(ABCExchange):
             ):
                 if log:
                     log.debug(
-                        "Ignoring excluded file '{}' (see config option "
+                        'Ignoring excluded file "{}" (see config option '
                         'CourseDirectory.ignore)'.format(fullname)
                     )
                 return True
@@ -306,14 +306,14 @@ class Exchange(ABCExchange):
             ):
                 if log:
                     log.debug(
-                        "Ignoring non included file '{}' (see config "
+                        'Ignoring non included file "{}" (see config '
                         'option CourseDirectory.include)'.format(fullname)
                     )
                 return True
             elif max_file_size and filesize > 1000 * max_file_size:
                 if log:
                     log.warning(
-                        "Ignoring file too large '{}' (see config "
+                        'Ignoring file too large "{}" (see config '
                         'option CourseDirectory.max_file_size)'.format(fullname)
                     )
                 return True

--- a/ngshare_exchange/fetch_assignment.py
+++ b/ngshare_exchange/fetch_assignment.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import os
+from urllib.parse import quote
 
 from nbgrader.exchange.abc import (
     ExchangeFetchAssignment as ABCExchangeFetchAssignment,
@@ -33,9 +34,11 @@ class ExchangeFetchAssignment(Exchange, ABCExchangeFetchAssignment):
         ):
             self.fail('You do not have access to this course.')
 
-        self.src_path = '/assignment/{}/{}'.format(
+        
+        url = '/assignment/{}/{}'.format(
             self.coursedir.course_id, self.coursedir.assignment_id
         )
+        self.src_path = quote(url, safe='/', encoding=None, errors=None)
 
     def init_dest(self):
         if self.path_includes_course:

--- a/ngshare_exchange/fetch_assignment.py
+++ b/ngshare_exchange/fetch_assignment.py
@@ -34,7 +34,6 @@ class ExchangeFetchAssignment(Exchange, ABCExchangeFetchAssignment):
         ):
             self.fail('You do not have access to this course.')
 
-        
         url = '/assignment/{}/{}'.format(
             self.coursedir.course_id, self.coursedir.assignment_id
         )

--- a/ngshare_exchange/fetch_assignment.py
+++ b/ngshare_exchange/fetch_assignment.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 import os
-from urllib.parse import quote
 
 from nbgrader.exchange.abc import (
     ExchangeFetchAssignment as ABCExchangeFetchAssignment,
@@ -34,10 +33,9 @@ class ExchangeFetchAssignment(Exchange, ABCExchangeFetchAssignment):
         ):
             self.fail('You do not have access to this course.')
 
-        url = '/assignment/{}/{}'.format(
+        self.src_path = '/assignment/{}/{}'.format(
             self.coursedir.course_id, self.coursedir.assignment_id
         )
-        self.src_path = quote(url, safe='/', encoding=None, errors=None)
 
     def init_dest(self):
         if self.path_includes_course:
@@ -57,7 +55,7 @@ class ExchangeFetchAssignment(Exchange, ABCExchangeFetchAssignment):
             )
 
     def do_copy(self, files):
-        """Copy the src dir to the dest dir omitting the self.coursedir.ignore globs."""
+        '''Copy the src dir to the dest dir omitting the self.coursedir.ignore globs.'''
         if os.path.isdir(self.dest_path):
             self.decode_dir(
                 files,

--- a/ngshare_exchange/list.py
+++ b/ngshare_exchange/list.py
@@ -15,12 +15,12 @@ def _checksum(path):
 
 
 def _merge_notebooks_feedback(notebook_ids, checksums):
-    """
-    Returns a list of dictionaries with "notebook_id" and "feedback_checksum".
+    '''
+    Returns a list of dictionaries with 'notebook_id' and 'feedback_checksum'.
 
     ``notebook_ids`` - A list of notebook IDs.
     ``checksum`` - A dictionary mapping notebook IDs to checksums.
-    """
+    '''
     merged = []
     for nb_id in notebook_ids:
         if nb_id not in checksums.keys():
@@ -32,10 +32,10 @@ def _merge_notebooks_feedback(notebook_ids, checksums):
 
 
 def _parse_notebook_id(path, extension='.ipynb'):
-    """
+    '''
     Returns the notebook_id from the path. If the path is not a file with the
     extension, returns None.
-    """
+    '''
     split_name = os.path.splitext(os.path.split(path)[1])
     if split_name[1] == extension:
         return split_name[0]
@@ -44,12 +44,12 @@ def _parse_notebook_id(path, extension='.ipynb'):
 
 class ExchangeList(Exchange, ABCExchangeList):
     def _get_assignments(self, course_ids):
-        """
+        '''
         Returns a list of assignments. Each assignment is a dictionary
         containing the course_id and assignment_id.
 
         ``course_ids`` - A list of course IDs.
-        """
+        '''
         assignments = []
         for course_id in course_ids:
             response = self.ngshare_api_get('/assignments/{}'.format(course_id))
@@ -69,9 +69,9 @@ class ExchangeList(Exchange, ABCExchangeList):
         return assignments
 
     def _get_courses(self):
-        """
+        '''
         Returns a list of course_ids.
-        """
+        '''
 
         response = self.ngshare_api_get('/courses')
         if response is None:
@@ -81,11 +81,11 @@ class ExchangeList(Exchange, ABCExchangeList):
     def _get_feedback_checksums(
         self, course_id, assignment_id, student_id, timestamp
     ):
-        """
+        '''
         Returns the checksums of all feedback files for a specific submission.
         This is a dictionary mapping all notebook_ids to the feedback file's
         checksum.
-        """
+        '''
         url = '/feedback/{}/{}/{}'.format(course_id, assignment_id, student_id)
         params = {'list_only': 'true', 'timestamp': timestamp}
 
@@ -102,9 +102,9 @@ class ExchangeList(Exchange, ABCExchangeList):
         return checksums
 
     def _get_notebooks(self, course_id, assignment_id):
-        """
+        '''
         Returns a list of notebook_ids from the assignment.
-        """
+        '''
         url = '/assignment/{}/{}'.format(course_id, assignment_id)
         params = {'list_only': 'true'}
 
@@ -118,17 +118,17 @@ class ExchangeList(Exchange, ABCExchangeList):
         ]
 
     def _get_submissions(self, assignments, student_id=None):
-        """
+        '''
         Returns a list of submissions. Each submission is a dictionary
-        containing the "course_id", "assignment_id", "student_id", "timestamp"
-        and a list of "notebooks". Each notebook is a dictionary containing a
-        "notebook_id" and "feedback_checksum".
+        containing the 'course_id', 'assignment_id', 'student_id', 'timestamp'
+        and a list of 'notebooks'. Each notebook is a dictionary containing a
+        'notebook_id' and 'feedback_checksum'.
 
-        ``assignments`` - A list of dictionaries containing "course_id" and
-        "assignment_id".
+        ``assignments`` - A list of dictionaries containing 'course_id' and
+        'assignment_id'.
         ``student_id`` - Used to specify a specific student's submissions to
         get. If None, submissions from all students are fetched if permitted.
-        """
+        '''
         submissions = []
         for assignment in assignments:
             course_id = assignment['course_id']
@@ -188,9 +188,9 @@ class ExchangeList(Exchange, ABCExchangeList):
     def _get_submission_notebooks(
         self, course_id, assignment_id, student_id, timestamp
     ):
-        """
+        '''
         Returns a list of notebook_ids from a submission.
-        """
+        '''
         url = '/submission/{}/{}/{}'.format(
             course_id, assignment_id, student_id
         )
@@ -209,9 +209,9 @@ class ExchangeList(Exchange, ABCExchangeList):
         return notebooks
 
     def _unrelease_assignment(self, course_id, assignment_id):
-        """
+        '''
         Unrelease a released assignment.
-        """
+        '''
         url = '/assignment/{}/{}'.format(course_id, assignment_id)
 
         return self.ngshare_api_delete(url)
@@ -271,34 +271,34 @@ class ExchangeList(Exchange, ABCExchangeList):
                 'timestamp': assignment['timestamp'],
             }
         elif self.cached:
-            regexp = r".*/(?P<course_id>.*)/(?P<student_id>.*)\+(?P<assignment_id>.*)\+(?P<timestamp>.*)"
+            regexp = r'.*/(?P<course_id>.*)/(?P<student_id>.*)\+(?P<assignment_id>.*)\+(?P<timestamp>.*)'
         else:
             return assignment
 
         m = re.match(regexp, assignment)
         if m is None:
             raise RuntimeError(
-                "Could not match '%s' with regexp '%s'", assignment, regexp
+                'Could not match "%s" with regexp "%s"', assignment, regexp
             )
         return m.groupdict()
 
     def format_inbound_assignment(self, info):
-        msg = "{course_id} {student_id} {assignment_id} {timestamp}".format(
+        msg = '{course_id} {student_id} {assignment_id} {timestamp}'.format(
             **info
         )
         if info['status'] == 'submitted':
             if info['has_local_feedback'] and not info['feedback_updated']:
-                msg += " (feedback already fetched)"
+                msg += ' (feedback already fetched)'
             elif info['has_exchange_feedback']:
-                msg += " (feedback ready to be fetched)"
+                msg += ' (feedback ready to be fetched)'
             else:
-                msg += " (no feedback available)"
+                msg += ' (no feedback available)'
         return msg
 
     def format_outbound_assignment(self, info):
-        msg = "{course_id} {assignment_id}".format(**info)
+        msg = '{course_id} {assignment_id}'.format(**info)
         if os.path.exists(info['assignment_id']):
-            msg += " (already downloaded)"
+            msg += ' (already downloaded)'
         return msg
 
     def copy_files(self):
@@ -517,32 +517,32 @@ class ExchangeList(Exchange, ABCExchangeList):
         return assignments
 
     def list_files(self):
-        """List files."""
+        '''List files.'''
         assignments = self.parse_assignments()
 
         if self.inbound or self.cached:
-            self.log.info("Submitted assignments:")
+            self.log.info('Submitted assignments:')
             for assignment in assignments:
                 for info in assignment['submissions']:
                     self.log.info(self.format_inbound_assignment(info))
         else:
-            self.log.info("Released assignments:")
+            self.log.info('Released assignments:')
             for info in assignments:
                 self.log.info(self.format_outbound_assignment(info))
 
         return assignments
 
     def remove_files(self):
-        """List and remove files."""
+        '''List and remove files.'''
         assignments = self.parse_assignments()
 
         if self.inbound or self.cached:
-            self.log.info("Removing submitted assignments:")
+            self.log.info('Removing submitted assignments:')
             for assignment in assignments:
                 for info in assignment['submissions']:
                     self.log.info(self.format_inbound_assignment(info))
         else:
-            self.log.info("Removing released assignments:")
+            self.log.info('Removing released assignments:')
             for info in assignments:
                 self.log.info(self.format_outbound_assignment(info))
 

--- a/ngshare_exchange/release_assignment.py
+++ b/ngshare_exchange/release_assignment.py
@@ -47,7 +47,7 @@ class ExchangeReleaseAssignment(Exchange, ABCExchangeReleaseAssignment):
 
                 # Looks like the instructor forgot to assign
                 self.fail(
-                    "Assignment found in '{}' but not '{}', run `nbgrader generate_assignment` first.".format(
+                    'Assignment found in "{}" but not "{}", run `nbgrader generate_assignment` first.'.format(
                         source, self.src_path
                     )
                 )
@@ -61,7 +61,7 @@ class ExchangeReleaseAssignment(Exchange, ABCExchangeReleaseAssignment):
 
     def init_dest(self):
         if self.coursedir.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
+            self.fail('No course id specified. Re-run with --course flag.')
         self.dest_path = '/assignment/{}/{}'.format(
             self.coursedir.course_id, self.coursedir.assignment_id
         )
@@ -81,7 +81,7 @@ class ExchangeReleaseAssignment(Exchange, ABCExchangeReleaseAssignment):
         if self.coursedir.assignment_id in response['assignments']:
             if self.force:
                 self.log.info(
-                    "Overwriting files: {} {}".format(
+                    'Overwriting files: {} {}'.format(
                         self.coursedir.course_id, self.coursedir.assignment_id
                     )
                 )

--- a/ngshare_exchange/release_feedback.py
+++ b/ngshare_exchange/release_feedback.py
@@ -23,7 +23,7 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
 
     def init_dest(self):
         if self.coursedir.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
+            self.fail('No course id specified. Re-run with --course flag.')
 
     def copy_files(self):
         if self.coursedir.student_id_exclude:
@@ -32,23 +32,23 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
             exclude_students = set()
 
         staged_feedback = {}  # Maps student IDs to submissions.
-        html_files = glob.glob(os.path.join(self.src_path, "*.html"))
+        html_files = glob.glob(os.path.join(self.src_path, '*.html'))
         for html_file in html_files:
             regexp = re.escape(os.path.sep).join(
                 [
                     self.coursedir.format_path(
                         self.coursedir.feedback_directory,
-                        "(?P<student_id>.*)",
+                        '(?P<student_id>.*)',
                         self.coursedir.assignment_id,
                         escape=True,
                     ),
-                    "(?P<notebook_id>.*).html",
+                    '(?P<notebook_id>.*).html',
                 ]
             )
 
             m = re.match(regexp, html_file)
             if m is None:
-                msg = "Could not match '%s' with regexp '%s'" % (
+                msg = 'Could not match "%s" with regexp "%s"' % (
                     html_file,
                     regexp,
                 )
@@ -59,7 +59,7 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
             student_id = gd['student_id']
             notebook_id = gd['notebook_id']
             if student_id in exclude_students:
-                self.log.debug("Skipping student '{}'".format(student_id))
+                self.log.debug('Skipping student "{}"'.format(student_id))
                 continue
 
             feedback_dir = os.path.split(html_file)[0]
@@ -79,8 +79,8 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
         for student_id, submission in staged_feedback.items():  # Student.
             for timestamp, feedback_info in submission.items():  # Submission.
                 self.log.info(
-                    "Releasing feedback for student '{}' on "
-                    "assignment '{}/{}/{}' ({})".format(
+                    'Releasing feedback for student "{}" on '
+                    'assignment "{}/{}/{}" ({})'.format(
                         student_id,
                         self.coursedir.course_id,
                         self.coursedir.assignment_id,
@@ -97,12 +97,12 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
                     self.log.info('Feedback released.')
 
     def post_feedback(self, student_id, timestamp, feedback_info):
-        """
+        '''
         Uploads feedback files for a specific submission.
         ``feedback_info`` - A list of feedback files. Each feedback file is
-        represented as a dictionary with a "path" to the local feedback file and
-        "notebook_id" of the corresponding notebook.
-        """
+        represented as a dictionary with a 'path' to the local feedback file and
+        'notebook_id' of the corresponding notebook.
+        '''
         url = '/feedback/{}/{}/{}'.format(
             self.coursedir.course_id, self.coursedir.assignment_id, student_id
         )

--- a/ngshare_exchange/release_feedback.py
+++ b/ngshare_exchange/release_feedback.py
@@ -69,15 +69,18 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
                 timestamp = timestamp_file.read()
 
             if student_id not in staged_feedback.keys():
-                staged_feedback[student_id] = {}  # Maps timestamp to feedback.
+                # Maps timestamp to feedback.
+                staged_feedback[student_id] = {}
             if timestamp not in staged_feedback[student_id].keys():
-                staged_feedback[student_id][timestamp] = []  # List of info.
+                # List of info.
+                staged_feedback[student_id][timestamp] = []
             staged_feedback[student_id][timestamp].append(
                 {'notebook_id': notebook_id, 'path': html_file}
             )
-
-        for student_id, submission in staged_feedback.items():  # Student.
-            for timestamp, feedback_info in submission.items():  # Submission.
+        # Student.
+        for student_id, submission in staged_feedback.items():
+            # Submission.
+            for timestamp, feedback_info in submission.items():
                 self.log.info(
                     'Releasing feedback for student "{}" on '
                     'assignment "{}/{}/{}" ({})'.format(

--- a/ngshare_exchange/submit.py
+++ b/ngshare_exchange/submit.py
@@ -1,10 +1,8 @@
-import base64
 import os
-import json
 
 from nbgrader.exchange.abc import ExchangeSubmit as ABCExchangeSubmit
 from .exchange import Exchange
-from nbgrader.utils import find_all_notebooks, parse_utc
+from nbgrader.utils import find_all_notebooks
 
 
 class ExchangeSubmit(Exchange, ABCExchangeSubmit):
@@ -46,13 +44,6 @@ class ExchangeSubmit(Exchange, ABCExchangeSubmit):
             self.fail('No course id specified. Re-run with --course flag.')
 
         self.cache_path = os.path.join(self.cache, self.coursedir.course_id)
-        if self.coursedir.student_id != '*':
-            self.fail(
-                'Submitting assignments with an explicit student ID is '
-                'not possible with ngshare.'
-            )
-        else:
-            student_id = self.username
 
     def check_filename_diff(self):
         released_notebooks = self._get_assignment_notebooks(

--- a/ngshare_exchange/submit.py
+++ b/ngshare_exchange/submit.py
@@ -9,9 +9,9 @@ from nbgrader.utils import find_all_notebooks, parse_utc
 
 class ExchangeSubmit(Exchange, ABCExchangeSubmit):
     def _get_assignment_notebooks(self, course_id, assignment_id):
-        """
+        '''
         Returns a list of relative paths for all files in the assignment.
-        """
+        '''
         url = '/assignment/{}/{}'.format(course_id, assignment_id)
         params = {'list_only': 'true'}
 
@@ -30,10 +30,10 @@ class ExchangeSubmit(Exchange, ABCExchangeSubmit):
             root = os.path.join(
                 self.coursedir.course_id, self.coursedir.assignment_id
             )
-            other_path = os.path.join(self.coursedir.course_id, "*")
+            other_path = os.path.join(self.coursedir.course_id, '*')
         else:
             root = self.coursedir.assignment_id
-            other_path = "*"
+            other_path = '*'
         self.src_path = os.path.abspath(os.path.join(self.assignment_dir, root))
         self.coursedir.assignment_id = os.path.split(self.src_path)[-1]
         if not os.path.isdir(self.src_path):
@@ -43,7 +43,7 @@ class ExchangeSubmit(Exchange, ABCExchangeSubmit):
 
     def init_dest(self):
         if self.coursedir.course_id == '':
-            self.fail("No course id specified. Re-run with --course flag.")
+            self.fail('No course id specified. Re-run with --course flag.')
 
         self.cache_path = os.path.join(self.cache, self.coursedir.course_id)
         if self.coursedir.student_id != '*':
@@ -68,36 +68,36 @@ class ExchangeSubmit(Exchange, ABCExchangeSubmit):
         release_diff = list()
         for filename in released_notebooks:
             if filename in submitted_notebooks:
-                release_diff.append("{}: {}".format(filename, 'FOUND'))
+                release_diff.append('{}: {}'.format(filename, 'FOUND'))
             else:
                 missing = True
-                release_diff.append("{}: {}".format(filename, 'MISSING'))
+                release_diff.append('{}: {}'.format(filename, 'MISSING'))
 
         # Look for extra notebooks in submitted notebooks
         extra = False
         submitted_diff = list()
         for filename in submitted_notebooks:
             if filename in released_notebooks:
-                submitted_diff.append("{}: {}".format(filename, 'OK'))
+                submitted_diff.append('{}: {}'.format(filename, 'OK'))
             else:
                 extra = True
-                submitted_diff.append("{}: {}".format(filename, 'EXTRA'))
+                submitted_diff.append('{}: {}'.format(filename, 'EXTRA'))
 
         if missing or extra:
-            diff_msg = "Expected:\n\t{}\nSubmitted:\n\t{}".format(
+            diff_msg = 'Expected:\n\t{}\nSubmitted:\n\t{}'.format(
                 '\n\t'.join(release_diff), '\n\t'.join(submitted_diff),
             )
             if missing and self.strict:
                 self.fail(
-                    "Assignment {} not submitted. "
-                    "There are missing notebooks for the submission:\n{}"
-                    "".format(self.coursedir.assignment_id, diff_msg)
+                    'Assignment {} not submitted. '
+                    'There are missing notebooks for the submission:\n{}'
+                    ''.format(self.coursedir.assignment_id, diff_msg)
                 )
             else:
                 self.log.warning(
-                    "Possible missing notebooks and/or extra notebooks "
-                    "submitted for assignment {}:\n{}"
-                    "".format(self.coursedir.assignment_id, diff_msg)
+                    'Possible missing notebooks and/or extra notebooks '
+                    'submitted for assignment {}:\n{}'
+                    ''.format(self.coursedir.assignment_id, diff_msg)
                 )
 
     def post_submission(self, src_path):
@@ -112,7 +112,7 @@ class ExchangeSubmit(Exchange, ABCExchangeSubmit):
         return response['timestamp']
 
     def copy_files(self):
-        self.log.info("Source: {}".format(self.src_path))
+        self.log.info('Source: {}'.format(self.src_path))
 
         # copy to the real location
         self.check_filename_diff()
@@ -131,11 +131,11 @@ class ExchangeSubmit(Exchange, ABCExchangeSubmit):
         if not os.path.isdir(self.cache_path):
             os.makedirs(self.cache_path)
         self.do_copy(self.src_path, cache_path)
-        with open(os.path.join(cache_path, "timestamp.txt"), "w") as fh:
+        with open(os.path.join(cache_path, 'timestamp.txt'), 'w') as fh:
             fh.write(self.timestamp)
 
         self.log.info(
-            "Submitted as: {} {} {}".format(
+            'Submitted as: {} {} {}'.format(
                 self.coursedir.course_id,
                 self.coursedir.assignment_id,
                 str(self.timestamp),

--- a/ngshare_exchange/submit.py
+++ b/ngshare_exchange/submit.py
@@ -44,6 +44,11 @@ class ExchangeSubmit(Exchange, ABCExchangeSubmit):
             self.fail('No course id specified. Re-run with --course flag.')
 
         self.cache_path = os.path.join(self.cache, self.coursedir.course_id)
+        if self.coursedir.student_id != '*':
+            self.fail(
+                'Submitting assignments with an explicit student ID is '
+                'not possible with ngshare.'
+            )
 
     def check_filename_diff(self):
         released_notebooks = self._get_assignment_notebooks(

--- a/ngshare_exchange/tests/test_course_management.py
+++ b/ngshare_exchange/tests/test_course_management.py
@@ -12,7 +12,6 @@ import requests_mock as rq_mock
 from requests_mock import Mocker
 import urllib
 import tempfile
-from urllib.parse import quote
 from .. import course_management as cm
 
 
@@ -27,8 +26,7 @@ def parse_body(body: str):
     return dict(urllib.parse.parse_qsl(body))
 
 
-url = 'http://127.0.0.1:12121/api'
-NGSHARE_URL = quote(url, safe='/', encoding=None, errors=None)
+NGSHARE_URL = 'http://127.0.0.1:12121/api'
 global _ngshare_url
 cm._ngshare_url = NGSHARE_URL
 

--- a/ngshare_exchange/tests/test_course_management.py
+++ b/ngshare_exchange/tests/test_course_management.py
@@ -12,6 +12,7 @@ import requests_mock as rq_mock
 from requests_mock import Mocker
 import urllib
 import tempfile
+from urllib.parse import quote
 from .. import course_management as cm
 
 
@@ -26,7 +27,8 @@ def parse_body(body: str):
     return dict(urllib.parse.parse_qsl(body))
 
 
-NGSHARE_URL = 'http://127.0.0.1:12121/api'
+url = 'http://127.0.0.1:12121/api'
+NGSHARE_URL = quote(url, safe='/', encoding=None, errors=None)
 global _ngshare_url
 cm._ngshare_url = NGSHARE_URL
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     ],
     python_requires='>=3.6',
     install_requires=[
-        'fuzzywuzzy',
+        'rapidfuzz',
         'traitlets',
         'jupyter_core',
         #'nbgrader>=0.7.0',  # unfortunately not out yet?


### PR DESCRIPTION
* use single quotes constantly in exchange classes
* encode urls in `exchange.py`
* update `exchange.py` to use rapidfuzz see [this](https://github.com/jupyter/nbgrader/pull/1319)